### PR TITLE
fix: typo in comment

### DIFF
--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -8,7 +8,7 @@ namespace splitbrain\slika;
  */
 abstract class Adapter
 {
-    /** @var string path tot he image */
+    /** @var string path to the image */
     protected $imagepath;
 
     /** @var array Adapter Options */


### PR DESCRIPTION
Just a small typo in the documentation part of the source code.