### PR TITLE
Fix compatibility with PHP 8.3.0

### DIFF
--- a/src/GdAdapter.php
+++ b/src/GdAdapter.php
@@ -90,13 +90,13 @@ class GdAdapter extends Adapter
 
         // rotate
         if (in_array($orientation, [3, 4])) {
-            $image = imagerotate($this->image, 180, $transparency, 1);
+            $image = imagerotate($this->image, 180, $transparency);
         }
         if (in_array($orientation, [5, 6])) {
-            $image = imagerotate($this->image, -90, $transparency, 1);
+            $image = imagerotate($this->image, -90, $transparency);
             list($this->width, $this->height) = [$this->height, $this->width];
         } elseif (in_array($orientation, [7, 8])) {
-            $image = imagerotate($this->image, 90, $transparency, 1);
+            $image = imagerotate($this->image, 90, $transparency);
             list($this->width, $this->height) = [$this->height, $this->width];
         }
         /** @var resource $image is now defined */


### PR DESCRIPTION
The `imagerotate()` function used to take 3 parameters. Then, in PHP 5.1.0, an optional fourth parameter was added. And now, in PHP 8.3.0, that parameter has been removed. Since the code in `GdAdapter` always explicitly provides the fourth parameter when calling the function, this causes it to fail with an `ArgumentCountError` under PHP 8.3.0.

This commit removes the unused fourth parameter from all call sites.